### PR TITLE
Update skipped Prism tests to use Prism::fake() mocking

### DIFF
--- a/tests/Feature/Prism/ChatTest.php
+++ b/tests/Feature/Prism/ChatTest.php
@@ -6,6 +6,8 @@ namespace Tests\Feature\Prism;
 
 use Illuminate\Support\Facades\Notification;
 use Prism\Prism\Prism;
+use Prism\Prism\Testing\TextResponseFake;
+use Prism\Prism\ValueObjects\Usage;
 use Tests\TestCase;
 
 class ChatTest extends TestCase
@@ -14,16 +16,11 @@ class ChatTest extends TestCase
     {
         Notification::fake();
 
-        Prism::fake([
-            'text' => 'This is a fake Laravel tip about using Eloquent relationships effectively.',
-            'usage' => (object) [
-                'promptTokens' => 85,
-                'completionTokens' => 42,
-                'cacheWriteInputTokens' => 0,
-                'cacheReadInputTokens' => 0,
-                'thoughtTokens' => 0,
-            ],
-        ]);
+        $fakeResponse = TextResponseFake::make()
+            ->withText('This is a fake Laravel tip about using Eloquent relationships effectively.')
+            ->withUsage(new Usage(85, 42));
+
+        Prism::fake([$fakeResponse]);
 
         $response = $this->artisan('prism:chat:tips');
 

--- a/tests/Feature/Prism/ChatTest.php
+++ b/tests/Feature/Prism/ChatTest.php
@@ -4,13 +4,29 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Prism;
 
+use Illuminate\Support\Facades\Notification;
+use Prism\Prism\Prism;
 use Tests\TestCase;
 
 class ChatTest extends TestCase
 {
     public function test_tips(): void
     {
-        // Skip this test for now due to Bedrock provider compatibility issue
-        $this->markTestSkipped('Prism/Bedrock provider compatibility issue - bedrock package has missing abstract method implementations');
+        Notification::fake();
+
+        Prism::fake([
+            'text' => 'This is a fake Laravel tip about using Eloquent relationships effectively.',
+            'usage' => (object) [
+                'promptTokens' => 85,
+                'completionTokens' => 42,
+                'cacheWriteInputTokens' => 0,
+                'cacheReadInputTokens' => 0,
+                'thoughtTokens' => 0,
+            ],
+        ]);
+
+        $response = $this->artisan('prism:chat:tips');
+
+        $response->assertSuccessful();
     }
 }

--- a/tests/Feature/Prism/ReleaseTest.php
+++ b/tests/Feature/Prism/ReleaseTest.php
@@ -4,13 +4,41 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Prism;
 
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Notification;
+use Prism\Prism\Prism;
 use Tests\TestCase;
 
 class ReleaseTest extends TestCase
 {
     public function test_release(): void
     {
-        // Skip this test for now due to Bedrock provider compatibility issue
-        $this->markTestSkipped('Prism/Bedrock provider compatibility issue - bedrock package has missing abstract method implementations');
+        Notification::fake();
+
+        Http::fake([
+            '*' => Http::response([
+                [
+                    'published_at' => now()->toDateTimeString(),
+                    'body' => 'This is a test release with new features and bug fixes.',
+                    'tag_name' => 'v10.0.0',
+                    'html_url' => 'https://github.com/laravel/framework/releases/tag/v10.0.0',
+                ],
+            ]),
+        ]);
+
+        Prism::fake([
+            'text' => 'これは新機能とバグ修正を含むテストリリースです。',
+            'usage' => (object) [
+                'promptTokens' => 120,
+                'completionTokens' => 58,
+                'cacheWriteInputTokens' => 0,
+                'cacheReadInputTokens' => 0,
+                'thoughtTokens' => 0,
+            ],
+        ]);
+
+        $response = $this->artisan('prism:chat:release');
+
+        $response->assertSuccessful();
     }
 }

--- a/tests/Feature/Prism/ReleaseTest.php
+++ b/tests/Feature/Prism/ReleaseTest.php
@@ -7,6 +7,8 @@ namespace Tests\Feature\Prism;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Notification;
 use Prism\Prism\Prism;
+use Prism\Prism\Testing\TextResponseFake;
+use Prism\Prism\ValueObjects\Usage;
 use Tests\TestCase;
 
 class ReleaseTest extends TestCase
@@ -26,16 +28,11 @@ class ReleaseTest extends TestCase
             ]),
         ]);
 
-        Prism::fake([
-            'text' => 'これは新機能とバグ修正を含むテストリリースです。',
-            'usage' => (object) [
-                'promptTokens' => 120,
-                'completionTokens' => 58,
-                'cacheWriteInputTokens' => 0,
-                'cacheReadInputTokens' => 0,
-                'thoughtTokens' => 0,
-            ],
-        ]);
+        $fakeResponse = TextResponseFake::make()
+            ->withText('これは新機能とバグ修正を含むテストリリースです。')
+            ->withUsage(new Usage(120, 58));
+
+        Prism::fake([$fakeResponse]);
 
         $response = $this->artisan('prism:chat:release');
 


### PR DESCRIPTION
Fixes #503

Updated the currently skipped Prism tests to use `Prism::fake()` for mocking instead of being skipped.

## Changes
- Replace `markTestSkipped()` calls with proper test implementations
- Add `Prism::fake()` with mocked responses matching expected structure
- Add `Notification::fake()` to mock notification channels
- Add `Http::fake()` for GitHub API calls in ReleaseTest
- Tests now follow same pattern as OpenAI tests but with Prism-specific mocking

Generated with [Claude Code](https://claude.ai/code)