### PR TITLE
feat: expand prompt variety for Laravel tips generation

### DIFF
--- a/app/Console/Commands/OpenAI/ChatTipsCommand.php
+++ b/app/Console/Commands/OpenAI/ChatTipsCommand.php
@@ -59,10 +59,58 @@ class ChatTipsCommand extends Command
     protected function prompt(): string
     {
         $prompt = collect([
+            // Advanced tips
             'Tell me one advanced Laravel tips.',
-            // 'Select one page from the official Laravel documentation and explain it.',
-            // 'Generate one Laravel Frequently Asked Questions and Answers.',
-            // 'Generate one unusual question and answer for Laravel.',
+            'Share an advanced Laravel technique that many developers don\'t know about.',
+            'Explain one Laravel feature that can significantly improve code performance.',
+            'Describe a lesser-known Laravel method that can simplify complex tasks.',
+
+            // Documentation-based
+            'Select one page from the official Laravel documentation and explain it with a practical example.',
+            'Pick a Laravel feature from the docs and show how to use it in a real-world scenario.',
+
+            // Q&A format
+            'Generate one Laravel Frequently Asked Questions and Answers.',
+            'Generate one unusual question and answer for Laravel.',
+            'Create a challenging Laravel interview question with a detailed answer.',
+
+            // Best practices
+            'Share one Laravel best practice that improves code maintainability.',
+            'Explain one Laravel security best practice with an example.',
+            'Describe one Laravel testing best practice that developers should follow.',
+
+            // Performance & optimization
+            'Share one Laravel performance optimization tip with code examples.',
+            'Explain how to optimize Laravel database queries with a practical example.',
+            'Describe one Laravel caching strategy that can boost application performance.',
+
+            // Eloquent & database
+            'Share one advanced Eloquent ORM tip with a practical example.',
+            'Explain one Laravel database migration technique that solves common problems.',
+            'Describe one Laravel relationship feature that simplifies data retrieval.',
+
+            // Architecture & patterns
+            'Explain one Laravel design pattern implementation with code examples.',
+            'Share one Laravel service container tip that improves dependency injection.',
+            'Describe one Laravel middleware technique for solving common problems.',
+
+            // Modern Laravel features
+            'Explain one Laravel feature introduced in recent versions with practical usage.',
+            'Share one Laravel Livewire or Inertia.js tip for better user experiences.',
+            'Describe one Laravel API resource technique for better API development.',
+
+            // Debugging & troubleshooting
+            'Share one Laravel debugging technique that helps identify issues quickly.',
+            'Explain one Laravel logging strategy that improves application monitoring.',
+            'Describe one Laravel error handling pattern with implementation details.',
+
+            // Artisan & CLI
+            'Share one useful Laravel Artisan command with practical examples.',
+            'Explain how to create a custom Laravel Artisan command for a specific task.',
+
+            // Configuration & environment
+            'Share one Laravel configuration tip that improves application flexibility.',
+            'Explain one Laravel environment management technique for different deployment stages.',
         ])->random();
 
         $lang = Lottery::odds(chances: 5, outOf: 10)

--- a/app/Console/Commands/Prism/ChatTipsCommand.php
+++ b/app/Console/Commands/Prism/ChatTipsCommand.php
@@ -71,10 +71,58 @@ class ChatTipsCommand extends Command
     protected function prompt(): string
     {
         $prompt = collect([
+            // Advanced tips
             'Tell me one advanced Laravel tips.',
-            // 'Select one page from the official Laravel documentation and explain it.',
-            // 'Generate one Laravel Frequently Asked Questions and Answers.',
-            // 'Generate one unusual question and answer for Laravel.',
+            'Share an advanced Laravel technique that many developers don\'t know about.',
+            'Explain one Laravel feature that can significantly improve code performance.',
+            'Describe a lesser-known Laravel method that can simplify complex tasks.',
+
+            // Documentation-based
+            'Select one page from the official Laravel documentation and explain it with a practical example.',
+            'Pick a Laravel feature from the docs and show how to use it in a real-world scenario.',
+
+            // Q&A format
+            'Generate one Laravel Frequently Asked Questions and Answers.',
+            'Generate one unusual question and answer for Laravel.',
+            'Create a challenging Laravel interview question with a detailed answer.',
+
+            // Best practices
+            'Share one Laravel best practice that improves code maintainability.',
+            'Explain one Laravel security best practice with an example.',
+            'Describe one Laravel testing best practice that developers should follow.',
+
+            // Performance & optimization
+            'Share one Laravel performance optimization tip with code examples.',
+            'Explain how to optimize Laravel database queries with a practical example.',
+            'Describe one Laravel caching strategy that can boost application performance.',
+
+            // Eloquent & database
+            'Share one advanced Eloquent ORM tip with a practical example.',
+            'Explain one Laravel database migration technique that solves common problems.',
+            'Describe one Laravel relationship feature that simplifies data retrieval.',
+
+            // Architecture & patterns
+            'Explain one Laravel design pattern implementation with code examples.',
+            'Share one Laravel service container tip that improves dependency injection.',
+            'Describe one Laravel middleware technique for solving common problems.',
+
+            // Modern Laravel features
+            'Explain one Laravel feature introduced in recent versions with practical usage.',
+            'Share one Laravel Livewire or Inertia.js tip for better user experiences.',
+            'Describe one Laravel API resource technique for better API development.',
+
+            // Debugging & troubleshooting
+            'Share one Laravel debugging technique that helps identify issues quickly.',
+            'Explain one Laravel logging strategy that improves application monitoring.',
+            'Describe one Laravel error handling pattern with implementation details.',
+
+            // Artisan & CLI
+            'Share one useful Laravel Artisan command with practical examples.',
+            'Explain how to create a custom Laravel Artisan command for a specific task.',
+
+            // Configuration & environment
+            'Share one Laravel configuration tip that improves application flexibility.',
+            'Explain one Laravel environment management technique for different deployment stages.',
         ])->random();
 
         $lang = Lottery::odds(chances: 5, outOf: 10)


### PR DESCRIPTION
Fixes #509

Expanded the Laravel tips bot prompts from 4 options (1 active) to 32 diverse prompts covering:

- Advanced Laravel techniques and lesser-known features
- Documentation-based explanations with examples
- Q&A format including interview questions
- Best practices for maintainability, security, and testing
- Performance optimization and caching strategies
- Eloquent ORM and database techniques
- Architecture patterns and design implementations
- Modern Laravel features (Livewire, Inertia.js, API resources)
- Debugging and troubleshooting techniques
- Artisan CLI and custom commands
- Configuration and environment management

Updated both Prism and OpenAI implementations for consistency.

Generated with [Claude Code](https://claude.ai/code)